### PR TITLE
Update BetterAlign extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Change Log
+v 0.1.3
+- Replaced wwm.better-align with Chouzz.vscode-better-align
+
 v 0.1.2
 - Added Postman
 

--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ MediaAlpha Extension Pack is a collection of popular extensions that can help wr
 
 - It helps you to navigate in your code, moving between important positions easily and quickly. No more need to search for code. It also supports a set of selection commands, which allows you to select bookmarked lines and regions between bookmarked lines. It's really useful for log file analysis.
 
-[Better Align](https://marketplace.visualstudio.com/items?itemName=wwm.better-align)
+[Better Align](https://marketplace.visualstudio.com/items?itemName=Chouzz.vscode-better-align)
 
-- Align your code by colon(:), assignment(=,+=,-=,*=,/=) and arrow(=>). It has additional support for comma-first coding style and trailing comment.
+- Better vertical alignment with/without selection in any language for any characters or words.
 
 [Code Runner](https://marketplace.visualstudio.com/items?itemName=formulahendry.code-runner)
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "MediaAlpha Extension Pack",
     "description": "MediaAlpha Development Environment Extension Pack",
     "publisher": "YanfeiShao",
-    "version": "0.1.2",
+    "version": "0.1.3",
 	"icon": "ma-icon.png",
 	"preview": true,
 	"keywords": [
@@ -27,7 +27,7 @@
     	"janjoerke.align-by-regex",
 		"cweijan.vscode-mysql-client2",
 		"awarest.awarest-align",
-		"wwm.better-align",
+		"Chouzz.vscode-better-align",
 		"alefragnani.bookmarks",
 		"formulahendry.code-runner",
 		"streetsidesoftware.code-spell-checker",


### PR DESCRIPTION
The BetterAlign extension is deprecated. This replaces it with the current fork.